### PR TITLE
Learn go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ base: docker ## Builds base container
 openssl: base ## Builds an openssl container
 	docker build --rm ./common/openssl --build-arg BASEIMAGE=$(BASE_IMAGE_TAG) --build-arg VERSION=$(OPENSSL_VERSION) -t $(OPENSSL_IMAGE_TAG)
 
-go: base ## Builds a go build container
-	docker build --rm ./common/go --build-arg BASEIMAGE=$(BASE_IMAGE_TAG) --build-arg VERSION=$(GO_VERSION) -t $(GO_IMAGE_TAG)
+go: base openssl ## Builds a go build container
+	docker build --rm ./common/go --build-arg BASEIMAGE=$(BASE_IMAGE_TAG) --build-arg OPENSSLIMAGE=$(OPENSSL_IMAGE_TAG) --build-arg VERSION=$(GO_VERSION) -t $(GO_IMAGE_TAG)
 
 node: base ## Builds a nodejs build container
 	docker build --rm ./common/node --build-arg BASEIMAGE=$(BASE_IMAGE_TAG) --build-arg VERSION=$(NODE_VERSION) -t $(NODE_IMAGE_TAG)

--- a/common/go/Dockerfile
+++ b/common/go/Dockerfile
@@ -1,4 +1,7 @@
 ARG BASEIMAGE=
+ARG OPENSSLIMAGE=
+
+FROM ${OPENSSLIMAGE} as openssl
 
 FROM ${BASEIMAGE} AS build
 ARG VERSION=
@@ -23,6 +26,9 @@ RUN grep ${ARCHIVE} SHA256SUM.txt | sha256sum -c -
 RUN tar xzf $ARCHIVE
 
 FROM ${BASEIMAGE} AS final
+
+WORKDIR /etc/ssl/certs
+COPY --from=openssl /etc/ssl/certs/ca-certificates.crt .
 
 WORKDIR ${GOROOT}
 COPY --from=build /usr/local/src/go/src ./src


### PR DESCRIPTION
I was learning go, so I made some changes to the go container build to make it more practical.

This includes:
- scraping the golang download page and extracting the shasum based on the go version that is specified. This is probably pretty brittle!
- updating go to the latest version
- adding `make tidy` to clean up dangling intermediate build images from docker
- dropping openssl known CA certificates into the final go image so that public https:// endpoints are trusted

Closes #6 
